### PR TITLE
feat: Add Activity Compose for image picking

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -117,6 +117,9 @@ dependencies {
     implementation(libs.okhttp) // OkHttp client
     implementation(libs.okhttp.logging.interceptor) // OkHttp logging interceptor
 
+    // Add image picker and upload functionality
+    implementation(libs.androidx.activity.compose.v182)
+
     // Unit Tests (run on local JVM)
     testImplementation(libs.junit) // Standard JUnit4
     testImplementation(libs.kotlinx.coroutines.test) // For testing coroutines

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,7 @@
 # It helps in managing dependencies centrally.
 
 [versions]
+activityComposeVersion = "1.8.2"
 agp = "8.10.0" # Android Gradle Plugin version
 coreKtxVersion = "1.6.1"
 kotlin = "2.1.20" # Kotlin version
@@ -37,6 +38,7 @@ runner = "1.6.2" # androidx.test:runner
 uiTestJunit4Android = "1.8.2" # androidx.compose.ui:ui-test-junit4-android (Requires compileSdk 35)
 
 [libraries]
+androidx-activity-compose-v182 = { module = "androidx.activity:activity-compose", version.ref = "activityComposeVersion" }
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 androidx-material-icons-extended = { module = "androidx.compose.material:material-icons-extended" } # No version needed if using BOM for Compose
 


### PR DESCRIPTION
This commit introduces the `androidx.activity:activity-compose` library to enable image picker and upload functionality.

The following changes were made:
- Added `androidx.activity.compose.v182` to `app/build.gradle.kts`.
- Defined `activityComposeVersion = "1.8.2"` and the corresponding library `androidx-activity-compose-v182` in `gradle/libs.versions.toml`.