### PR TITLE
Perbaikan: Bikin fitur posting lebih oke & benerin respons dari API

### DIFF
--- a/app/src/main/java/com/virtualsblog/project/data/mapper/PostMapper.kt
+++ b/app/src/main/java/com/virtualsblog/project/data/mapper/PostMapper.kt
@@ -5,7 +5,7 @@ import com.virtualsblog.project.data.remote.dto.response.PostResponse
 import com.virtualsblog.project.domain.model.Post
 
 object PostMapper {
-    
+
     fun mapResponseToDomain(response: PostResponse): Post {
         return Post(
             id = response.id,
@@ -17,14 +17,15 @@ object PostMapper {
             createdAt = response.createdAt,
             updatedAt = response.updatedAt,
             category = response.category.name,
-            likes = response.count.Like,
-            comments = response.count.Comment,
+            // FIXED: Handle null count safely - post baru biasanya belum ada like/comment
+            likes = response.count?.Like ?: 0,
+            comments = response.count?.Comment ?: 0,
             isLiked = response.liked,
             image = response.image,
             slug = response.slug
         )
     }
-    
+
     fun mapResponseListToDomain(responseList: List<PostResponse>): List<Post> {
         return responseList.map { mapResponseToDomain(it) }
     }
@@ -40,8 +41,9 @@ object PostMapper {
             category = response.category.name,
             createdAt = response.createdAt,
             updatedAt = response.updatedAt,
-            likes = response.count.Like,
-            comments = response.count.Comment,
+            // FIXED: Handle null count safely - detail post juga bisa null pada kasus tertentu
+            likes = response.count?.Like ?: 0,
+            comments = response.count?.Comment ?: 0,
             isLiked = response.liked,
             image = response.image,
             slug = response.slug

--- a/app/src/main/java/com/virtualsblog/project/data/remote/api/BlogApi.kt
+++ b/app/src/main/java/com/virtualsblog/project/data/remote/api/BlogApi.kt
@@ -4,6 +4,7 @@ import com.virtualsblog.project.data.remote.dto.response.CategoriesApiResponse
 import com.virtualsblog.project.data.remote.dto.response.PostResponse
 import com.virtualsblog.project.data.remote.dto.response.PostsApiResponse
 import com.virtualsblog.project.data.remote.dto.response.PostDetailApiResponse
+import com.virtualsblog.project.data.remote.dto.response.ApiResponse
 import com.virtualsblog.project.util.Constants
 import okhttp3.MultipartBody
 import okhttp3.RequestBody
@@ -11,7 +12,7 @@ import retrofit2.Response
 import retrofit2.http.*
 
 interface BlogApi {
-    
+
     @GET("posts")
     suspend fun getAllPosts(
         @Header(Constants.HEADER_API_KEY) apiKey: String = Constants.API_KEY,
@@ -28,17 +29,18 @@ interface BlogApi {
     @GET("categories")
     suspend fun getCategories(
         @Header(Constants.HEADER_AUTHORIZATION) authorization: String,
-        @Header(Constants.HEADER_API_KEY) apiKey: String
+        @Header(Constants.HEADER_API_KEY) apiKey: String = Constants.API_KEY
     ): Response<CategoriesApiResponse>
-    
+
+    // FIXED: Response type should be wrapped in ApiResponse based on API documentation
     @Multipart
     @POST("posts")
     suspend fun createPost(
-        @Header("X-API-KEY") apiKey: String, // Or however you pass the API Key
-        @Header("Authorization") authorization: String, // This is the parameter name
+        @Header("X-API-KEY") apiKey: String = Constants.API_KEY,
+        @Header("Authorization") authorization: String,
         @Part("title") title: RequestBody,
         @Part("content") content: RequestBody,
-        @Part("category_id") categoryId: RequestBody,
+        @Part("categoryId") categoryId: RequestBody,
         @Part photo: MultipartBody.Part
-    ): Response<PostResponse>
+    ): Response<ApiResponse<PostResponse>> // FIXED: Wrap in ApiResponse
 }

--- a/app/src/main/java/com/virtualsblog/project/data/remote/dto/response/PostResponse.kt
+++ b/app/src/main/java/com/virtualsblog/project/data/remote/dto/response/PostResponse.kt
@@ -49,8 +49,9 @@ data class PostResponse(
     val category: CategoryResponse,
     @SerializedName("Comment")
     val comments: List<CommentResponse> = emptyList(),
+    // FIXED: Make count nullable - post baru mungkin belum ada count
     @SerializedName("_count")
-    val count: CountResponse,
+    val count: CountResponse? = null,
     @SerializedName("like")
     val liked: Boolean = false
 )
@@ -80,8 +81,9 @@ data class PostDetailResponse(
     val category: CategoryResponse,
     @SerializedName("Comment")
     val comments: List<CommentResponse> = emptyList(),
+    // FIXED: Make count nullable - detail post juga bisa null
     @SerializedName("_count")
-    val count: CountResponse,
+    val count: CountResponse? = null,
     @SerializedName("like")
     val liked: Boolean = false
 )

--- a/app/src/main/java/com/virtualsblog/project/data/repository/BlogRepositoryImpl.kt
+++ b/app/src/main/java/com/virtualsblog/project/data/repository/BlogRepositoryImpl.kt
@@ -29,17 +29,17 @@ class BlogRepositoryImpl @Inject constructor(
     override suspend fun getAllPosts(): Flow<Resource<List<Post>>> = flow {
         try {
             emit(Resource.Loading())
-            
+
             val token = authRepository.getAuthToken()
             if (token.isNullOrEmpty()) {
                 emit(Resource.Error(Constants.ERROR_UNAUTHORIZED))
                 return@flow
             }
-            
+
             val response = blogApi.getAllPosts(
                 authorization = "${Constants.BEARER_PREFIX}$token"
             )
-            
+
             if (response.isSuccessful) {
                 val body = response.body()
                 if (body != null && body.success) {
@@ -69,17 +69,17 @@ class BlogRepositoryImpl @Inject constructor(
     override suspend fun getPostsForHome(): Flow<Resource<List<Post>>> = flow {
         try {
             emit(Resource.Loading())
-            
+
             val token = authRepository.getAuthToken()
             if (token.isNullOrEmpty()) {
                 emit(Resource.Error(Constants.ERROR_UNAUTHORIZED))
                 return@flow
             }
-            
+
             val response = blogApi.getAllPosts(
                 authorization = "${Constants.BEARER_PREFIX}$token"
             )
-            
+
             if (response.isSuccessful) {
                 val body = response.body()
                 if (body != null && body.success) {
@@ -111,17 +111,17 @@ class BlogRepositoryImpl @Inject constructor(
     override suspend fun getTotalPostsCount(): Flow<Resource<Int>> = flow {
         try {
             emit(Resource.Loading())
-            
+
             val token = authRepository.getAuthToken()
             if (token.isNullOrEmpty()) {
                 emit(Resource.Error(Constants.ERROR_UNAUTHORIZED))
                 return@flow
             }
-            
+
             val response = blogApi.getAllPosts(
                 authorization = "${Constants.BEARER_PREFIX}$token"
             )
-            
+
             if (response.isSuccessful) {
                 val body = response.body()
                 if (body != null && body.success) {
@@ -140,18 +140,18 @@ class BlogRepositoryImpl @Inject constructor(
     override suspend fun getPostById(postId: String): Flow<Resource<Post>> = flow {
         try {
             emit(Resource.Loading())
-            
+
             val token = authRepository.getAuthToken()
             if (token.isNullOrEmpty()) {
                 emit(Resource.Error(Constants.ERROR_UNAUTHORIZED))
                 return@flow
             }
-            
+
             val response = blogApi.getPostById(
                 postId = postId,
                 authorization = "${Constants.BEARER_PREFIX}$token"
             )
-            
+
             if (response.isSuccessful) {
                 val body = response.body()
                 if (body != null && body.success) {
@@ -177,18 +177,18 @@ class BlogRepositoryImpl @Inject constructor(
     override suspend fun getCategories(): Flow<Resource<List<Category>>> = flow {
         try {
             emit(Resource.Loading())
-            
+
             val token = authRepository.getAuthToken()
             if (token.isNullOrEmpty()) {
                 emit(Resource.Error(Constants.ERROR_UNAUTHORIZED))
                 return@flow
             }
-            
+
             val response = blogApi.getCategories(
                 authorization = "${Constants.BEARER_PREFIX}$token",
                 apiKey = Constants.API_KEY
             )
-            
+
             if (response.isSuccessful) {
                 val body = response.body()
                 if (body != null && body.success) {
@@ -218,67 +218,112 @@ class BlogRepositoryImpl @Inject constructor(
     ): Flow<Resource<Post>> = flow {
         try {
             emit(Resource.Loading())
-            
+
             val token = authRepository.getAuthToken()
             if (token.isNullOrEmpty()) {
                 emit(Resource.Error(Constants.ERROR_UNAUTHORIZED))
                 return@flow
             }
 
-            // PERSIS seperti AuthRepositoryImpl - pattern yang sudah proven work!
+            // Validasi file gambar
+            if (!photo.exists() || photo.length() == 0L) {
+                emit(Resource.Error("File gambar tidak valid"))
+                return@flow
+            }
+
+            if (photo.length() > Constants.MAX_IMAGE_SIZE) {
+                emit(Resource.Error("Ukuran file maksimal 10MB"))
+                return@flow
+            }
+
+            // Validasi ekstensi file
+            val allowedExtensions = listOf("jpg", "jpeg", "png")
+            val fileExtension = photo.extension.lowercase()
+            if (!allowedExtensions.contains(fileExtension)) {
+                emit(Resource.Error("Tipe file tidak diizinkan. Gunakan JPG, JPEG, atau PNG"))
+                return@flow
+            }
+
+            // MIME type sesuai dengan yang digunakan di AuthRepositoryImpl
+            val mimeType = when (fileExtension) {
+                "jpg", "jpeg" -> "image/jpeg"
+                "png" -> "image/png"
+                else -> "image/jpeg"
+            }
+
             // Create multipart request body
             val titleBody = title.toRequestBody("text/plain".toMediaTypeOrNull())
             val contentBody = content.toRequestBody("text/plain".toMediaTypeOrNull())
             val categoryIdBody = categoryId.toRequestBody("text/plain".toMediaTypeOrNull())
-            
-            // File handling PERSIS seperti uploadProfilePicture di AuthRepositoryImpl
-            val requestFile = photo.asRequestBody("image/*".toMediaTypeOrNull())
+
+            // File handling sama persis dengan uploadProfilePicture
+            val requestFile = photo.asRequestBody(mimeType.toMediaTypeOrNull())
             val photoPart = MultipartBody.Part.createFormData("photo", photo.name, requestFile)
 
-            // API call dengan pattern AuthApi
+            // API call
             val response = blogApi.createPost(
                 apiKey = Constants.API_KEY,
-                authorization = "Bearer $token", // Changed 'token' to 'authorization'
+                authorization = "Bearer $token",
                 title = titleBody,
                 content = contentBody,
                 categoryId = categoryIdBody,
                 photo = photoPart
             )
-            
+
             if (response.isSuccessful) {
                 val body = response.body()
-                if (body != null) {
-                    val post = PostMapper.mapResponseToDomain(body)
+                if (body != null && body.success) {
+                    // FIXED: Access data from ApiResponse wrapper
+                    val post = PostMapper.mapResponseToDomain(body.data)
                     emit(Resource.Success(post))
                 } else {
-                    emit(Resource.Error("Response body kosong dari server"))
+                    emit(Resource.Error(body?.message ?: "Gagal membuat postingan"))
                 }
             } else {
-                // Error handling seperti AuthRepositoryImpl
+                // Error handling yang konsisten dengan AuthRepositoryImpl
                 val errorBody = response.errorBody()?.string()
                 val errorMessage = when (response.code()) {
-                    400 -> "Data yang dikirim tidak valid: $errorBody"
+                    400 -> {
+                        when {
+                            errorBody?.contains("File type not allowed") == true ->
+                                "Tipe file tidak diizinkan. Gunakan JPG, JPEG, atau PNG"
+                            errorBody?.contains("photo wajib diisi") == true ->
+                                "Gambar wajib diupload"
+                            else -> "Data yang dikirim tidak valid"
+                        }
+                    }
                     401 -> Constants.ERROR_UNAUTHORIZED
                     403 -> "Tidak memiliki akses untuk membuat postingan"
                     413 -> "File terlalu besar (maksimal 10MB)"
-                    422 -> "Data validasi gagal: $errorBody"
-                    500 -> {
-                        // Parse error message dari server seperti AuthRepositoryImpl
-                        if (errorBody?.contains("File type not allowed") == true) {
-                            "Tipe file tidak diizinkan. Gunakan JPG, JPEG, atau PNG"
-                        } else {
-                            "Server Error: $errorBody"
+                    422 -> {
+                        when {
+                            errorBody?.contains("Judul wajib minimal") == true ->
+                                "Judul postingan minimal 3 karakter"
+                            errorBody?.contains("Konten wajib minimal") == true ->
+                                "Konten postingan minimal 10 karakter"
+                            errorBody?.contains("Category ID") == true ->
+                                "Kategori tidak valid"
+                            else -> "Data tidak valid"
                         }
                     }
-                    else -> "HTTP ${response.code()}: ${response.message()}"
+                    500 -> {
+                        when {
+                            errorBody?.contains("File type not allowed", ignoreCase = true) == true ->
+                                "Tipe file tidak diizinkan. Gunakan JPG, JPEG, atau PNG"
+                            errorBody?.contains("Failed to upload file", ignoreCase = true) == true ->
+                                "Gagal mengunggah file ke server"
+                            else -> "Terjadi kesalahan pada server"
+                        }
+                    }
+                    else -> "Error: ${response.code()} - ${response.message()}"
                 }
                 emit(Resource.Error(errorMessage))
             }
         } catch (e: Exception) {
             val errorMessage = when {
-                e.message?.contains("timeout", ignoreCase = true) == true -> 
+                e.message?.contains("timeout", ignoreCase = true) == true ->
                     "Request timeout - coba lagi"
-                e.message?.contains("connect", ignoreCase = true) == true -> 
+                e.message?.contains("connect", ignoreCase = true) == true ->
                     Constants.ERROR_NETWORK
                 e.message?.contains("json", ignoreCase = true) == true ->
                     "Error parsing response dari server"

--- a/app/src/main/java/com/virtualsblog/project/presentation/ui/screen/post/create/CreatePostScreen.kt
+++ b/app/src/main/java/com/virtualsblog/project/presentation/ui/screen/post/create/CreatePostScreen.kt
@@ -29,7 +29,6 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import coil.compose.AsyncImage
 import com.virtualsblog.project.presentation.ui.theme.extendedColors
 import com.virtualsblog.project.util.Constants
-import com.virtualsblog.project.util.FileUtils
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -41,49 +40,32 @@ fun CreatePostScreen(
     val uiState by viewModel.uiState.collectAsState()
     val context = LocalContext.current
 
-    // Image picker launcher dengan validation yang sama seperti ProfileScreen
+    // FIXED: Image picker launcher seperti di ProfileScreen
     val imagePickerLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.GetContent()
     ) { uri: Uri? ->
         uri?.let {
-            try {
-                val file = FileUtils.getFileFromUri(context, it)
-                if (file != null) {
-                    viewModel.updateSelectedImage(file, it.toString())
-                } else {
-                    // Error handling konsisten dengan ProfileScreen
-                    viewModel.updateSelectedImage(null, null)
-                }
-            } catch (e: Exception) {
-                viewModel.updateSelectedImage(null, null)
-            }
+            // Pattern sama dengan ProfileScreen - langsung panggil ViewModel
+            viewModel.updateSelectedImage(context, it)
         }
     }
 
-    // Handle successful post creation - konsisten dengan pattern lain
+    // Handle successful post creation
     LaunchedEffect(uiState.isSuccess) {
         if (uiState.isSuccess) {
             onPostCreated()
         }
     }
 
-    // Handle error clearing - konsisten dengan HomeScreen
-    LaunchedEffect(uiState.error) {
-        if (uiState.error != null) {
-            // Auto clear error after some time if needed
-        }
-    }
-
     Scaffold(
         topBar = {
-            // Enhanced TopBar - konsisten dengan PostDetailScreen style
             Surface(
                 modifier = Modifier.fillMaxWidth(),
                 color = MaterialTheme.colorScheme.surface,
                 shadowElevation = 4.dp
             ) {
                 TopAppBar(
-                    title = { 
+                    title = {
                         Text(
                             text = Constants.CREATE_POST_TEXT,
                             style = MaterialTheme.typography.titleLarge,
@@ -99,13 +81,12 @@ fun CreatePostScreen(
                         }
                     },
                     actions = {
-                        // Enhanced Publish Button - konsisten dengan style lain
                         FilledTonalButton(
-                            onClick = { 
+                            onClick = {
                                 viewModel.createPost()
                             },
-                            enabled = !uiState.isLoading && 
-                                    uiState.title.isNotBlank() && 
+                            enabled = !uiState.isLoading &&
+                                    uiState.title.isNotBlank() &&
                                     uiState.content.isNotBlank() &&
                                     uiState.selectedCategory != null &&
                                     uiState.selectedImageFile != null,
@@ -129,7 +110,7 @@ fun CreatePostScreen(
                     colors = TopAppBarDefaults.topAppBarColors(
                         containerColor = MaterialTheme.colorScheme.surface
                     ),
-                    modifier = Modifier.padding(top = 8.dp) // Konsisten dengan screens lain
+                    modifier = Modifier.padding(top = 8.dp)
                 )
             }
         }
@@ -147,15 +128,15 @@ fun CreatePostScreen(
                     .padding(horizontal = 24.dp, vertical = 16.dp),
                 verticalArrangement = Arrangement.spacedBy(20.dp)
             ) {
-                // Enhanced Title Input Card - konsisten dengan DetailScreen style
+                // Title Input Card
                 EnhancedCreatePostCard(
                     title = Constants.POST_TITLE_TEXT,
                     content = {
                         OutlinedTextField(
                             value = uiState.title,
                             onValueChange = { viewModel.updateTitle(it) },
-                            placeholder = { 
-                                Text(Constants.POST_TITLE_HINT) 
+                            placeholder = {
+                                Text(Constants.POST_TITLE_HINT)
                             },
                             modifier = Modifier.fillMaxWidth(),
                             colors = OutlinedTextFieldDefaults.colors(
@@ -165,8 +146,7 @@ fun CreatePostScreen(
                             shape = RoundedCornerShape(12.dp),
                             isError = uiState.titleError != null
                         )
-                        
-                        // Enhanced Error Display
+
                         if (uiState.titleError != null) {
                             Spacer(modifier = Modifier.height(4.dp))
                             Text(
@@ -178,14 +158,13 @@ fun CreatePostScreen(
                     }
                 )
 
-                // Enhanced Category Selection - konsisten dengan HomeScreen dropdown style
+                // Category Selection
                 EnhancedCreatePostCard(
                     title = Constants.POST_CATEGORY_TEXT,
                     content = {
                         var expanded by remember { mutableStateOf(false) }
 
                         if (uiState.isCategoriesLoading) {
-                            // Enhanced Loading State - konsisten dengan HomeScreen
                             Box(
                                 modifier = Modifier
                                     .fillMaxWidth()
@@ -225,7 +204,7 @@ fun CreatePostScreen(
                                     shape = RoundedCornerShape(12.dp),
                                     isError = uiState.categoryError != null
                                 )
-                                
+
                                 ExposedDropdownMenu(
                                     expanded = expanded,
                                     onDismissRequest = { expanded = false }
@@ -242,7 +221,7 @@ fun CreatePostScreen(
                                 }
                             }
                         }
-                        
+
                         if (uiState.categoryError != null) {
                             Spacer(modifier = Modifier.height(4.dp))
                             Text(
@@ -254,15 +233,15 @@ fun CreatePostScreen(
                     }
                 )
 
-                // Enhanced Content Input - konsisten dengan style lain
+                // Content Input
                 EnhancedCreatePostCard(
                     title = Constants.POST_CONTENT_TEXT,
                     content = {
                         OutlinedTextField(
                             value = uiState.content,
                             onValueChange = { viewModel.updateContent(it) },
-                            placeholder = { 
-                                Text(Constants.POST_CONTENT_HINT) 
+                            placeholder = {
+                                Text(Constants.POST_CONTENT_HINT)
                             },
                             modifier = Modifier
                                 .fillMaxWidth()
@@ -286,14 +265,13 @@ fun CreatePostScreen(
                     }
                 )
 
-                // Enhanced Image Upload - konsisten dengan PostDetailScreen image handling
+                // FIXED: Image Upload section
                 EnhancedCreatePostCard(
                     title = "Gambar *",
                     content = {
                         Column {
                             OutlinedButton(
-                                onClick = { 
-                                    // Pastikan hanya memilih gambar seperti di ProfileScreen
+                                onClick = {
                                     imagePickerLauncher.launch("image/*")
                                 },
                                 modifier = Modifier.fillMaxWidth(),
@@ -307,10 +285,9 @@ fun CreatePostScreen(
                                 Spacer(modifier = Modifier.width(8.dp))
                                 Text("Pilih Gambar (JPG/PNG, Max 10MB)")
                             }
-                            
+
                             if (uiState.selectedImageUri != null) {
                                 Spacer(modifier = Modifier.height(12.dp))
-                                // Enhanced Image Preview - konsisten dengan PostDetailScreen
                                 Card(
                                     modifier = Modifier.fillMaxWidth(),
                                     shape = RoundedCornerShape(12.dp),
@@ -327,12 +304,12 @@ fun CreatePostScreen(
                                 }
                                 Spacer(modifier = Modifier.height(8.dp))
                                 Text(
-                                    text = "Gambar dipilih",
+                                    text = "✅ Gambar dipilih",
                                     style = MaterialTheme.typography.bodySmall,
                                     color = MaterialTheme.colorScheme.primary
                                 )
                             }
-                            
+
                             if (uiState.imageError != null) {
                                 Spacer(modifier = Modifier.height(4.dp))
                                 Text(
@@ -345,7 +322,7 @@ fun CreatePostScreen(
                     }
                 )
 
-                // Enhanced Error Message - konsisten dengan HomeScreen error handling
+                // Error Message
                 AnimatedVisibility(
                     visible = uiState.error != null,
                     enter = fadeIn() + expandVertically(),
@@ -386,7 +363,7 @@ fun CreatePostScreen(
                     }
                 }
 
-                // Enhanced Success Message - konsisten dengan pattern HomeScreen
+                // Success Message
                 AnimatedVisibility(
                     visible = uiState.isSuccess,
                     enter = fadeIn() + expandVertically(),
@@ -431,7 +408,6 @@ fun CreatePostScreen(
     }
 }
 
-// Enhanced CreatePostCard Component - konsisten dengan PostDetailScreen components
 @Composable
 private fun EnhancedCreatePostCard(
     title: String,

--- a/app/src/main/java/com/virtualsblog/project/presentation/ui/screen/post/create/CreatePostViewModel.kt
+++ b/app/src/main/java/com/virtualsblog/project/presentation/ui/screen/post/create/CreatePostViewModel.kt
@@ -1,5 +1,7 @@
 package com.virtualsblog.project.presentation.ui.screen.post.create
 
+import android.content.Context
+import android.net.Uri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.virtualsblog.project.domain.model.Category
@@ -14,7 +16,6 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import java.io.File
 import javax.inject.Inject
-import com.virtualsblog.project.util.FileUtils
 
 @HiltViewModel
 class CreatePostViewModel @Inject constructor(
@@ -32,7 +33,7 @@ class CreatePostViewModel @Inject constructor(
     private fun loadCategories() {
         viewModelScope.launch {
             _uiState.value = _uiState.value.copy(isCategoriesLoading = true)
-            
+
             try {
                 getCategoriesUseCase().collect { resource ->
                     when (resource) {
@@ -84,20 +85,91 @@ class CreatePostViewModel @Inject constructor(
         )
     }
 
-    fun updateSelectedImage(file: File?, uriString: String?) {
-        val imageError = when {
-            file == null -> "Pilih gambar untuk postingan"
-            !file.exists() -> "File gambar tidak ditemukan"
-            !FileUtils.isValidImageFile(file) -> "File harus berupa gambar JPG, JPEG, atau PNG"
-            file.length() > Constants.MAX_IMAGE_SIZE -> "Ukuran gambar maksimal 10MB"
-            else -> null
-        }
+    // SIMPLIFIED: Image handling method yang lebih sederhana dan reliable
+    fun updateSelectedImage(context: Context, imageUri: Uri) {
+        viewModelScope.launch {
+            try {
+                // Validasi MIME type
+                val mimeType = context.contentResolver.getType(imageUri)
+                if (mimeType == null || !isValidImageType(mimeType)) {
+                    _uiState.value = _uiState.value.copy(
+                        selectedImageFile = null,
+                        selectedImageUri = null,
+                        imageError = "File harus berupa gambar JPG, JPEG, atau PNG"
+                    )
+                    return@launch
+                }
 
-        _uiState.value = _uiState.value.copy(
-            selectedImageFile = if (imageError == null) file else null,
-            selectedImageUri = if (imageError == null) uriString else null,
-            imageError = imageError
-        )
+                // Baca input stream untuk validasi
+                val inputStream = context.contentResolver.openInputStream(imageUri)
+                if (inputStream == null) {
+                    _uiState.value = _uiState.value.copy(
+                        selectedImageFile = null,
+                        selectedImageUri = null,
+                        imageError = "Gagal membaca file gambar"
+                    )
+                    return@launch
+                }
+
+                // Read file content ke byte array untuk validasi ukuran
+                val fileBytes = inputStream.use { it.readBytes() }
+
+                if (fileBytes.size > Constants.MAX_IMAGE_SIZE) {
+                    _uiState.value = _uiState.value.copy(
+                        selectedImageFile = null,
+                        selectedImageUri = null,
+                        imageError = "Ukuran file maksimal 10MB"
+                    )
+                    return@launch
+                }
+
+                // Buat temporary file dengan nama yang proper
+                val fileExtension = getFileExtension(mimeType)
+                val fileName = "post_image_${System.currentTimeMillis()}.$fileExtension"
+                val tempFile = File(context.cacheDir, fileName)
+
+                // Write bytes ke file
+                tempFile.writeBytes(fileBytes)
+
+                // Validasi file hasil write
+                if (tempFile.exists() && tempFile.length() > 0) {
+                    _uiState.value = _uiState.value.copy(
+                        selectedImageFile = tempFile,
+                        selectedImageUri = imageUri.toString(),
+                        imageError = null
+                    )
+                } else {
+                    if (tempFile.exists()) tempFile.delete()
+                    _uiState.value = _uiState.value.copy(
+                        selectedImageFile = null,
+                        selectedImageUri = null,
+                        imageError = "Gagal memproses file gambar"
+                    )
+                }
+
+            } catch (e: Exception) {
+                _uiState.value = _uiState.value.copy(
+                    selectedImageFile = null,
+                    selectedImageUri = null,
+                    imageError = "Error: ${e.message}"
+                )
+            }
+        }
+    }
+
+    // Helper methods
+    private fun isValidImageType(mimeType: String): Boolean {
+        val allowedTypes = arrayOf("image/jpeg", "image/png", "image/jpg")
+        return allowedTypes.contains(mimeType.lowercase())
+    }
+
+    private fun getFileExtension(mimeType: String): String {
+        return when (mimeType.lowercase()) {
+            "image/jpeg" -> "jpg"
+            "image/jpg" -> "jpg"
+            "image/png" -> "png"
+            else -> "jpg"
+        }
     }
 
     fun createPost() {
@@ -161,15 +233,15 @@ class CreatePostViewModel @Inject constructor(
         val currentState = _uiState.value
         var hasError = false
 
-        // Validate title
+        // Validate title sesuai API requirement (minimal 3 karakter)
         val titleError = when {
             currentState.title.isBlank() -> {
                 hasError = true
-                Constants.VALIDATION_POST_TITLE_REQUIRED
+                "Judul postingan harus diisi"
             }
-            currentState.title.length < Constants.MIN_TITLE_LENGTH -> {
+            currentState.title.length < 3 -> { // API requirement
                 hasError = true
-                "Judul postingan minimal ${Constants.MIN_TITLE_LENGTH} karakter"
+                "Judul postingan minimal 3 karakter"
             }
             currentState.title.length > Constants.MAX_TITLE_LENGTH -> {
                 hasError = true
@@ -178,15 +250,15 @@ class CreatePostViewModel @Inject constructor(
             else -> null
         }
 
-        // Validate content
+        // Validate content sesuai API requirement (minimal 10 karakter)
         val contentError = when {
             currentState.content.isBlank() -> {
                 hasError = true
-                Constants.VALIDATION_POST_CONTENT_REQUIRED
+                "Konten postingan harus diisi"
             }
-            currentState.content.length < Constants.MIN_CONTENT_LENGTH -> {
+            currentState.content.length < 10 -> { // API requirement
                 hasError = true
-                "Konten postingan minimal ${Constants.MIN_CONTENT_LENGTH} karakter"
+                "Konten postingan minimal 10 karakter"
             }
             currentState.content.length > Constants.MAX_CONTENT_LENGTH -> {
                 hasError = true
@@ -204,7 +276,7 @@ class CreatePostViewModel @Inject constructor(
             else -> null
         }
 
-        // Validate image dengan pengecekan yang lebih ketat
+        // Validate image
         val imageError = when {
             currentState.selectedImageFile == null -> {
                 hasError = true
@@ -214,9 +286,13 @@ class CreatePostViewModel @Inject constructor(
                 hasError = true
                 "File gambar tidak ditemukan"
             }
-            !FileUtils.isValidImageFile(currentState.selectedImageFile) -> {
+            currentState.selectedImageFile.length() == 0L -> {
                 hasError = true
-                "File harus berupa gambar JPG, JPEG, atau PNG maksimal 10MB"
+                "File gambar kosong"
+            }
+            currentState.selectedImageFile.length() > Constants.MAX_IMAGE_SIZE -> {
+                hasError = true
+                "Ukuran gambar maksimal 10MB"
             }
             else -> null
         }


### PR DESCRIPTION
Commit ini nyempurnain fitur bikin posting dan cara nangani respons dari API:

Fitur Bikin Post:

Validasi gambar sekarang lebih kuat: cuma bisa JPG, JPEG, atau PNG, dan maksimal 10MB. Ini dicek di CreatePostViewModel dan BlogRepositoryImpl.

Cara ngambil dan ngecek file gambar juga diperbaiki, sekarang pakai content resolver buat cek MIME type dan ukurannya.

Tampilan di CreatePostScreen juga diperbarui, jadi pengguna bisa lihat status gambar yang dipilih dan pesan error-nya kalau ada masalah.

Validasi form juga disesuaikan: judul minimal 3 karakter dan isi posting minimal 10 karakter, sesuai aturan dari API.

Integrasi API & Data:

API createPost di BlogApi udah dibenerin supaya nerima ApiResponse<PostResponse> dan header categoryId ditulis dengan benar.

BlogRepositoryImpl sekarang:

Bisa nangkep dan nge-handle respons ApiResponse dari createPost.

Kasih pesan error yang lebih jelas dari API, kayak file kegedean, format file nggak cocok, atau ada input yang salah.

Di PostMapper, udah disiapin supaya aman kalau field count (jumlah like/komentar) masih null, misalnya buat postingan baru.

Field count di PostResponse dan PostDetailResponse sekarang nullable (boleh null).

Lain-lain:

Ada pembersihan kode dan nambahin komentar biar kodenya lebih gampang dipahami, terutama di BlogRepositoryImpl dan CreatePostScreen.