### PR TITLE
feat: Configure release signing and update build configurations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,8 @@
 .cxx
 local.properties
 /.github
+
+# Keystore files
+*.keystore
+*.jks
+


### PR DESCRIPTION
This commit introduces release signing capabilities and refines the build process:

**Signing Configuration:**
- Added a `signingConfigs` block in `app/build.gradle.kts` to define a "release" signing configuration.
- This configuration specifies the path to `my-release-key.keystore`, store password, key alias, and key password.
- The `release` build type now uses this signing configuration.

**.gitignore:**
- Added `*.keystore` and `*.jks` to `.gitignore` to prevent keystore files from being committed to the repository.

**Build Type Refinements:**
- **`debug` build type:**
    - Explicitly set `isDebuggable = true`.
    - Added `applicationIdSuffix = ".debug"`.
    - Added `versionNameSuffix = "-debug"`.
    - Retrieves `API_KEY` from `local.properties`, environment variable, or a fallback.
- **`release` build type:**
    - Set `isMinifyEnabled = true` and `isShrinkResources = true`.
    - Set `isDebuggable = false`.
    - Retrieves `API_KEY` prioritizing `PROD_API_KEY` environment variable, then `API_KEY` environment variable, or a fallback.

**Other `app/build.gradle.kts` changes:**
- Updated `versionName` from "1.0" to "1.0.0".
- Explicitly set `composeOptions.kotlinCompilerExtensionVersion = "1.5.14"`.
- Added more exclusions to `packaging.resources.excludes` to resolve potential conflicts, particularly with JUnit and related libraries.
- Minor cleanup of comments related to dependencies.