### PR TITLE
Refactor: Centralize API and App constants in BuildConfig

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -47,8 +47,18 @@ android {
 
         val apiKey = localProperties.getProperty("API_KEY") ?:
         System.getenv("API_KEY") ?:
-        "NpeW7lQ2SlZUCC9mI4G7E26NMRtoK8mW"
+        "Api_Key_Backend (bisa di request ke developer)"
 
+        val baseUrl = localProperties.getProperty("BASE_URL") ?:
+        System.getenv("BASE_URL") ?:
+        "https://be-prakmob.kodingin.id/api/v1/"
+
+        val appName = localProperties.getProperty("APP_NAME") ?:
+        System.getenv("APP_NAME") ?:
+        "VirtualsBlog"
+
+        buildConfigField("String", "BASE_URL", "\"$baseUrl\"")
+        buildConfigField("String", "APP_NAME", "\"$appName\"")
         buildConfigField("String", "API_KEY", "\"$apiKey\"")
     }
 
@@ -66,8 +76,18 @@ android {
 
             val apiKey = localProperties.getProperty("API_KEY") ?:
             System.getenv("API_KEY") ?:
-            "NpeW7lQ2SlZUCC9mI4G7E26NMRtoK8mW"
+            "Api_Key_Backend (bisa di request ke developer)"
 
+            val baseUrl = localProperties.getProperty("BASE_URL") ?:
+            System.getenv("BASE_URL") ?:
+            "https://be-prakmob.kodingin.id/api/v1/"
+
+            val appName = localProperties.getProperty("APP_NAME") ?:
+            System.getenv("APP_NAME") ?:
+            "VirtualsBlog"
+
+            buildConfigField("String", "BASE_URL", "\"$baseUrl\"")
+            buildConfigField("String", "APP_NAME", "\"$appName\"")
             buildConfigField("String", "API_KEY", "\"$apiKey\"")
         }
 

--- a/app/src/main/java/com/virtualsblog/project/util/Constants.kt
+++ b/app/src/main/java/com/virtualsblog/project/util/Constants.kt
@@ -3,10 +3,9 @@ import com.virtualsblog.project.BuildConfig
 
 object Constants {
     // Konfigurasi API
-    const val BASE_URL = "https://be-prakmob.kodingin.id/api/v1/"
-
-    // FIXED: Menggunakan BuildConfig yang sudah diperbaiki
+    val BASE_URL: String = BuildConfig.BASE_URL
     val API_KEY: String = BuildConfig.API_KEY
+
 
     // API Endpoints
     const val POSTS_ENDPOINT = "posts"


### PR DESCRIPTION
This commit modifies how API and application constants are handled:

- `BASE_URL` and `APP_NAME` are now defined as `buildConfigField` in `app/build.gradle.kts` for both `debug` and `release` build types. This allows them to be configurable via `local.properties` or environment variables, with default values provided.
- The `Constants.kt` file has been updated to source `BASE_URL` and `API_KEY` directly from the generated `BuildConfig` class.
- The hardcoded `BASE_URL` constant has been removed from `Constants.kt`.
- Placeholder default values for `API_KEY`, `BASE_URL`, and `APP_NAME` have been updated in `build.gradle.kts` to be more descriptive.